### PR TITLE
Added x86_64-linux platform to lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     diff-lcs (1.5.0)
     digest (3.1.0)
     erubi (1.10.0)
+    ffi (1.15.5)
     ffi (1.15.5-x64-mingw32)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -141,7 +142,10 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-x64-mingw32)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
+    pg (1.3.4)
     pg (1.3.4-x64-mingw32)
     public_suffix (4.0.6)
     puma (5.6.2)
@@ -245,6 +249,7 @@ GEM
 
 PLATFORMS
   x64-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
I added the x86_64-linux platform to the lockfile in order to fix the build error on render